### PR TITLE
feat: client context

### DIFF
--- a/lib/client/apollo-link-ddp.js
+++ b/lib/client/apollo-link-ddp.js
@@ -1,22 +1,30 @@
 import { ApolloLink, Observable, split } from 'apollo-link';
 import { Meteor } from 'meteor/meteor';
-import { DEFAULT_METHOD, DEFAULT_PUBLICATION } from '../common/defaults';
+import { DEFAULT_METHOD, DEFAULT_PUBLICATION, DEFAULT_CLIENT_CONTEXT_KEY } from '../common/defaults';
 import { isSubscription } from '../common/isSubscription';
 import listenToGraphQLMessages from './listenToGraphQLMessages';
+
+function getClientContext(operation, key = DEFAULT_CLIENT_CONTEXT_KEY) {
+  return operation.getContext && operation.getContext()[key];
+}
 
 export class DDPMethodLink extends ApolloLink {
   constructor({
     connection = Meteor.connection,
     method = DEFAULT_METHOD,
+    clientContextKey,
   } = {}) {
     super();
     this.connection = connection;
     this.method = method;
+    this.clientContextKey = clientContextKey;
   }
 
   request(operation = {}) {
+    const clientContext = getClientContext(operation, this.clientContextKey);
+
     return new Observable((observer) => {
-      this.connection.apply(this.method, [operation], (error, result) => {
+      this.connection.apply(this.method, [operation, clientContext], (error, result) => {
         if (error) {
           observer.error(error);
         } else {
@@ -34,10 +42,12 @@ export class DDPSubscriptionLink extends ApolloLink {
   constructor({
     connection = Meteor.connection,
     publication = DEFAULT_PUBLICATION,
+    clientContextKey,
   } = {}) {
     super();
     this.connection = connection;
     this.publication = publication;
+    this.clientContextKey = clientContextKey;
 
     this.subscriptionObservers = {};
 
@@ -54,7 +64,8 @@ export class DDPSubscriptionLink extends ApolloLink {
   }
 
   request(operation = {}) {
-    const subHandler = this.connection.subscribe(this.publication, operation);
+    const clientContext = getClientContext(operation, this.clientContextKey);
+    const subHandler = this.connection.subscribe(this.publication, operation, clientContext);
     const { subscriptionId: subId } = subHandler;
 
     return new Observable((observer) => {

--- a/lib/common/defaults.js
+++ b/lib/common/defaults.js
@@ -1,4 +1,5 @@
 export const DEFAULT_METHOD = '__graphql';
 export const DEFAULT_PUBLICATION = '__graphql-subscriptions';
+export const DEFAULT_CLIENT_CONTEXT_KEY = 'ddpContext';
 export const GRAPHQL_SUBSCRIPTION_MESSAGE_TYPE = 'graphql-sub-message';
 export const DEFAULT_CREATE_CONTEXT = context => context;

--- a/lib/server/createGraphQLMethod.js
+++ b/lib/server/createGraphQLMethod.js
@@ -10,7 +10,7 @@ export function createGraphQLMethod(schema, {
     throw new Error(DDP_APOLLO_SCHEMA_REQUIRED);
   }
 
-  return async function graphQlMethod({ query, variables, operationName } = {}) {
+  return async function graphQlMethod({ query, variables, operationName } = {}, clientContext) {
     if (!query) {
       return {};
     }
@@ -20,7 +20,7 @@ export function createGraphQLMethod(schema, {
     }
 
     const { userId } = this;
-    const context = await createContext({ userId });
+    const context = await createContext({ userId }, clientContext);
 
     return execute(
       schema,

--- a/lib/server/createGraphQLPublication.js
+++ b/lib/server/createGraphQLPublication.js
@@ -24,7 +24,7 @@ export function createGraphQLPublication({
     query,
     variables,
     operationName,
-  } = {}) {
+  } = {}, clientContext) {
     const {
       userId,
       _subscriptionId: subId,
@@ -37,7 +37,7 @@ export function createGraphQLPublication({
     }
 
     const subscribeToQuery = async () => {
-      const context = await createContext({ userId });
+      const context = await createContext({ userId }, clientContext);
 
       const iterator = await subscribe(
         schema,

--- a/specs/client/apollo-client.spec.js
+++ b/specs/client/apollo-client.spec.js
@@ -26,6 +26,15 @@ describe('ApolloClient with DDP link', function () {
       chai.expect(data.foo).to.be.a('string');
     });
 
+    it('should pass and retrieve a ddp context', async function () {
+      const { data } = await this.client.query({
+        query: gql`query { ddpContextValue }`,
+        context: { ddpContext: 'ddpFoo' },
+      });
+
+      chai.expect(data.ddpContextValue).to.equal('ddpFoo');
+    });
+
     it('returns subscription data', function (done) {
       const message = { fooSub: 'bar' };
       const observer = this.client.subscribe({ query: gql`subscription { fooSub }` });

--- a/specs/data/resolvers.js
+++ b/specs/data/resolvers.js
@@ -5,6 +5,7 @@ export const FOO_CHANGED_TOPIC = 'foo_changed';
 export const resolvers = {
   Query: {
     foo: () => 'bar',
+    ddpContextValue: (_, __, { ddpContext } = {}) => ddpContext,
   },
   Subscription: {
     fooSub: {

--- a/specs/data/typeDefs.js
+++ b/specs/data/typeDefs.js
@@ -1,6 +1,7 @@
 export const typeDefs = [`
 type Query {
   foo: String
+  ddpContextValue: String
 }
 
 type Subscription {

--- a/specs/server/helpers.js
+++ b/specs/server/helpers.js
@@ -23,7 +23,14 @@ Meteor.methods({
       typeDefs,
     });
 
-    setup({ schema });
+    setup({
+      schema,
+      // Add the client context to the previous context for testing
+      context: (previousContext, clientContext) => ({
+        ...previousContext,
+        ddpContext: clientContext,
+      }),
+    });
   },
 
   'ddp-apollo/publish': function publish(topic, data) {

--- a/specs/server/setup.spec.js
+++ b/specs/server/setup.spec.js
@@ -214,5 +214,25 @@ describe('#setup', function () {
         })
         .catch(done);
     });
+
+    it('accepts a ddp context param', function (done) {
+      const request = { query: gql`{ foo }` };
+
+      const schema = makeExecutableSchema({
+        resolvers: {
+          Query: { foo: (_, __, { foo }) => foo },
+        },
+        typeDefs,
+      });
+
+      const createContext = (_, clientContext) => clientContext;
+
+      createGraphQLMethod(schema, { createContext })(request, { foo: 'bar' })
+        .then(({ data }) => {
+          chai.expect(data.foo).to.equal('bar');
+          done();
+        })
+        .catch(done);
+    });
   });
 });

--- a/specs/server/setup.spec.js
+++ b/specs/server/setup.spec.js
@@ -178,9 +178,7 @@ describe('#setup', function () {
 
   describe('createContext', function () {
     it('is called with the current context', function (done) {
-      const request = {
-        query: gql`{ foo }`,
-      };
+      const request = { query: gql`{ foo }` };
 
       const schema = makeExecutableSchema({
         resolvers,
@@ -196,9 +194,7 @@ describe('#setup', function () {
     });
 
     it('returns a modified context', function (done) {
-      const request = {
-        query: gql`{ foo }`,
-      };
+      const request = { query: gql`{ foo }` };
 
       const schema = makeExecutableSchema({
         resolvers: {
@@ -209,12 +205,7 @@ describe('#setup', function () {
         typeDefs,
       });
 
-      function createContext() {
-        return {
-          foo: 'baz',
-          bar: 'qux',
-        };
-      }
+      const createContext = () => ({ foo: 'baz', bar: 'qux' });
 
       createGraphQLMethod(schema, { createContext })(request)
         .then(({ data }) => {


### PR DESCRIPTION
Add the option to pass contextual data to the server via a `ddpContext` key on `context`. This will be available as a second parameter in the `context` option on the server. Meaning things like extra auth headers or tokens can be passed on the fly.

`createContext` is also async so it can handle any fetching that might be required for authentication (or whatever).