### PR TITLE
feat(retry switch): add ddp retry switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ export const client = new ApolloClient ({
 - `connection`: The DDP connection to use. Default `Meteor.connection`.
 - `method`: The name of the method. Default `__graphql`.
 - `publication`: The name of the publication. Default `__graphql-subscriptions`.
+- `ddpRetry`: Retry failed DDP method calls. Default `true`. Switch off and use [apollo-link-retry](https://www.npmjs.com/package/apollo-link-retry) for more control.
 
 ```javascript
 // Pass options to the DDPLink constructor

--- a/lib/client/apollo-link-ddp.js
+++ b/lib/client/apollo-link-ddp.js
@@ -12,19 +12,23 @@ export class DDPMethodLink extends ApolloLink {
   constructor({
     connection = Meteor.connection,
     method = DEFAULT_METHOD,
+    ddpRetry = true,
     clientContextKey,
   } = {}) {
     super();
     this.connection = connection;
     this.method = method;
     this.clientContextKey = clientContextKey;
+    this.ddpRetry = ddpRetry;
   }
 
   request(operation = {}) {
     const clientContext = getClientContext(operation, this.clientContextKey);
+    const args = [operation, clientContext];
+    const options = { noRetry: !this.ddpRetry };
 
     return new Observable((observer) => {
-      this.connection.apply(this.method, [operation, clientContext], (error, result) => {
+      this.connection.apply(this.method, args, options, (error, result) => {
         if (error) {
           observer.error(error);
         } else {

--- a/specs/client/apollo-link-ddp.spec.js
+++ b/specs/client/apollo-link-ddp.spec.js
@@ -16,8 +16,10 @@ function callPromise(name, ...args) {
 }
 
 describe('DDPMethodLink', function () {
-  beforeEach(function () {
+  beforeEach(function (done) {
     this.link = new DDPMethodLink();
+
+    Meteor.call('ddp-apollo/setup', done);
   });
 
   it('should add a default method', function () {
@@ -32,6 +34,28 @@ describe('DDPMethodLink', function () {
 
       chai.expect(this.link.request(operation)).to.be.instanceof(Observable);
     });
+
+    it('returns data', function (done) {
+      const operation = {
+        query: gql`query { foo }`,
+      };
+
+      const observer = this.link.request(operation);
+
+      observer.subscribe({
+        next: ({ data }) => {
+          try {
+            chai.expect(data.foo).to.be.a('string');
+            done();
+          } catch (e) {
+            done(e);
+          }
+        },
+        error: done,
+      });
+    });
+  });
+
   });
 });
 


### PR DESCRIPTION
Users are probably better off using [https://www.npmjs.com/package/apollo-link-retry](apollo-link-retry), so they need to be able to switch of the DDP retry option. This PR solves that.