### PR TITLE
feat(auth): Add meteorAuthMiddleware for setting userId on the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ createGraphQLPublication({ schema });
 - `context`: A custom context. Either an object or a function returning an object. Optional.
 - `path`: The name of the HTTP path. Default `/graphql`.
 - `engine`: An Engine instance, in case you want monitoring on your HTTP endpoint. Optional.
+- `authMiddleware`: Middleware to get a userId and set it on the request. Default `meteorAuthMiddleware`, using a login token.
 - `jsonParser`: Custom JSON parser. Loads `body-parser` from your `node_modules` by default and uses `.json()`.
 
 ## Sponsor

--- a/lib/client/apollo-link-meteor-auth.js
+++ b/lib/client/apollo-link-meteor-auth.js
@@ -1,11 +1,10 @@
 import { ApolloLink } from 'apollo-link';
 import { getLoginToken } from './getLoginToken';
-import { DEFAULT_AUTH_HEADER } from '../common/defaults';
 
 export const meteorAuthLink = new ApolloLink((operation, forward) => {
   operation.setContext(() => ({
     headers: {
-      [DEFAULT_AUTH_HEADER]: getLoginToken(),
+      Authorization: `Bearer ${getLoginToken()}`,
     },
   }));
 

--- a/lib/client/apollo-link-meteor-auth.js
+++ b/lib/client/apollo-link-meteor-auth.js
@@ -4,7 +4,7 @@ import { getLoginToken } from './getLoginToken';
 export const meteorAuthLink = new ApolloLink((operation, forward) => {
   operation.setContext(() => ({
     headers: {
-      Authorization: `Bearer ${getLoginToken()}`,
+      Authorization: `Bearer ${getLoginToken() || ''}`,
     },
   }));
 

--- a/lib/client/apollo-link-meteor.js
+++ b/lib/client/apollo-link-meteor.js
@@ -15,9 +15,10 @@ export class MeteorLink extends ApolloLink {
     const {
       uri = Meteor.absoluteUrl(DEFAULT_PATH),
       httpLink,
+      authLink = meteorAuthLink,
     } = options;
 
-    this.meteorHttpLink = meteorAuthLink.concat(httpLink || new HttpLink({ uri }));
+    this.meteorHttpLink = authLink.concat(httpLink || new HttpLink({ uri }));
     this.subscriptionLink = new DDPSubscriptionLink(options);
   }
 

--- a/lib/common/defaults.js
+++ b/lib/common/defaults.js
@@ -3,5 +3,4 @@ export const DEFAULT_PUBLICATION = '__graphql-subscriptions';
 export const DEFAULT_CLIENT_CONTEXT_KEY = 'ddpContext';
 export const GRAPHQL_SUBSCRIPTION_MESSAGE_TYPE = 'graphql-sub-message';
 export const DEFAULT_PATH = '/graphql';
-export const DEFAULT_AUTH_HEADER = 'x-meteor-login-token';
 export const DEFAULT_CREATE_CONTEXT = context => context;

--- a/lib/server/createGraphQLMiddleware.js
+++ b/lib/server/createGraphQLMiddleware.js
@@ -1,7 +1,7 @@
 import { execute, parse } from 'graphql';
 import { contextToFunction } from './contextToFunction';
 
-export function createGraphQLRequestHandler({
+export function createGraphQLMiddleware({
   schema,
   context,
 }) {

--- a/lib/server/createGraphQLRequestHandler.js
+++ b/lib/server/createGraphQLRequestHandler.js
@@ -1,33 +1,9 @@
 import { execute, parse } from 'graphql';
-import { getUserByLoginToken, NO_VALID_USER_ERROR } from './getUserByLoginToken';
 import { contextToFunction } from './contextToFunction';
-import { DEFAULT_AUTH_HEADER } from '../common/defaults';
-
-async function defaultAuthorizer(req, {
-  authHeader = DEFAULT_AUTH_HEADER,
-}) {
-  // get the login token from the request headers, given by meteorAuthLink
-  const loginToken = req.headers[authHeader];
-
-  let user;
-
-  // get the user for the context
-  try {
-    user = await getUserByLoginToken(loginToken);
-  } catch (err) {
-    if (err !== NO_VALID_USER_ERROR) {
-      throw err;
-    }
-  }
-
-  return user && user._id;
-}
 
 export function createGraphQLRequestHandler({
   schema,
   context,
-  authHeader,
-  authorizer = defaultAuthorizer,
 }) {
   const createContext = contextToFunction(context);
 
@@ -38,13 +14,11 @@ export function createGraphQLRequestHandler({
       operationName,
     } = req.body;
 
-    const userId = await authorizer(req, { authHeader });
-
     const data = await execute(
       schema,
       parse(query),
       {},
-      await createContext({ userId }),
+      await createContext({ userId: req.userId }),
       variables,
       operationName,
     );

--- a/lib/server/getUserIdByLoginToken.js
+++ b/lib/server/getUserIdByLoginToken.js
@@ -1,7 +1,7 @@
 const USER_TOKEN_PATH = 'services.resume.loginTokens.hashedToken';
 export const NO_VALID_USER_ERROR = new Error('NO_VALID_USER');
 
-export async function getUserByLoginToken(loginToken) {
+export async function getUserIdByLoginToken(loginToken) {
   // `accounts-base` is a weak dependency, so we'll try to require it
   // eslint-disable-next-line global-require, prefer-destructuring
   const { Accounts } = require('meteor/accounts-base');
@@ -31,5 +31,5 @@ export async function getUserByLoginToken(loginToken) {
 
   if (isTokenExpired) { throw NO_VALID_USER_ERROR; }
 
-  return user;
+  return user._id;
 }

--- a/lib/server/meteorAuthMiddleware.js
+++ b/lib/server/meteorAuthMiddleware.js
@@ -1,4 +1,4 @@
-import { getUserByLoginToken, NO_VALID_USER_ERROR } from './getUserByLoginToken';
+import { getUserIdByLoginToken, NO_VALID_USER_ERROR } from './getUserIdByLoginToken';
 
 export function meteorAuthMiddleware(req, res, next) {
   let tokenType;
@@ -16,9 +16,9 @@ export function meteorAuthMiddleware(req, res, next) {
   }
 
   // get the user for the context
-  getUserByLoginToken(loginToken)
-    .then((user) => {
-      req.userId = user && user._id;
+  getUserIdByLoginToken(loginToken)
+    .then((userId) => {
+      req.userId = userId;
       next();
     })
     .catch((err) => {

--- a/lib/server/meteorAuthMiddleware.js
+++ b/lib/server/meteorAuthMiddleware.js
@@ -1,13 +1,17 @@
 import { getUserByLoginToken, NO_VALID_USER_ERROR } from './getUserByLoginToken';
 
 export function meteorAuthMiddleware(req, res, next) {
+  let bearer;
   let loginToken;
 
   // get the login token from the request headers, given by meteorAuthLink
   if (req.headers && req.headers.authorization) {
     const parts = req.headers.authorization.split(' ');
-    if (parts.length === 2 && parts[0] === 'Bearer') {
-      [loginToken] = parts;
+    [bearer, loginToken] = parts;
+
+    if (parts.length !== 2 || bearer !== 'Bearer') {
+      // Not a valid login token, so unset
+      loginToken = undefined;
     }
   }
 

--- a/lib/server/meteorAuthMiddleware.js
+++ b/lib/server/meteorAuthMiddleware.js
@@ -1,0 +1,23 @@
+import { getUserByLoginToken, NO_VALID_USER_ERROR } from './getUserByLoginToken';
+
+export function meteorAuthMiddleware(req, res, next) {
+  let loginToken;
+
+  // get the login token from the request headers, given by meteorAuthLink
+  if (req.headers && req.headers.authorization) {
+    const parts = req.headers.authorization.split(' ');
+    if (parts.length === 2 && parts[0] === 'Bearer') {
+      [loginToken] = parts;
+    }
+  }
+
+  // get the user for the context
+  getUserByLoginToken(loginToken)
+    .then((user) => {
+      req.userId = user && user._id;
+      next();
+    })
+    .catch((err) => {
+      err === NO_VALID_USER_ERROR ? next() : next(err);
+    });
+}

--- a/lib/server/meteorAuthMiddleware.js
+++ b/lib/server/meteorAuthMiddleware.js
@@ -1,15 +1,15 @@
 import { getUserByLoginToken, NO_VALID_USER_ERROR } from './getUserByLoginToken';
 
 export function meteorAuthMiddleware(req, res, next) {
-  let bearer;
+  let tokenType;
   let loginToken;
 
   // get the login token from the request headers, given by meteorAuthLink
   if (req.headers && req.headers.authorization) {
     const parts = req.headers.authorization.split(' ');
-    [bearer, loginToken] = parts;
+    [tokenType, loginToken] = parts;
 
-    if (parts.length !== 2 || bearer !== 'Bearer') {
+    if (parts.length !== 2 || tokenType !== 'Bearer') {
       // Not a valid login token, so unset
       loginToken = undefined;
     }

--- a/lib/server/setup.js
+++ b/lib/server/setup.js
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import { WebApp } from 'meteor/webapp';
 import { createGraphQLMethod } from './createGraphQLMethod';
 import { createGraphQLPublication } from './createGraphQLPublication';
-import { createGraphQLRequestHandler } from './createGraphQLRequestHandler';
+import { createGraphQLMiddleware } from './createGraphQLMiddleware';
 import { meteorAuthMiddleware } from './meteorAuthMiddleware';
 import {
   DEFAULT_METHOD,
@@ -47,7 +47,7 @@ export function setupHttpEndpoint({
     throw new Error(DDP_APOLLO_SCHEMA_REQUIRED);
   }
 
-  const requestHandler = createGraphQLRequestHandler({
+  const graphQLMiddleware = createGraphQLMiddleware({
     schema,
     context,
   });
@@ -70,5 +70,5 @@ export function setupHttpEndpoint({
     WebApp.connectHandlers.use(path, authMiddleware);
   }
 
-  WebApp.connectHandlers.use(path, (req, res, next) => requestHandler(req, res).catch(next));
+  WebApp.connectHandlers.use(path, (req, res, next) => graphQLMiddleware(req, res).catch(next));
 }

--- a/lib/server/setup.js
+++ b/lib/server/setup.js
@@ -3,6 +3,7 @@ import { WebApp } from 'meteor/webapp';
 import { createGraphQLMethod } from './createGraphQLMethod';
 import { createGraphQLPublication } from './createGraphQLPublication';
 import { createGraphQLRequestHandler } from './createGraphQLRequestHandler';
+import { meteorAuthMiddleware } from './meteorAuthMiddleware';
 import {
   DEFAULT_METHOD,
   DEFAULT_PATH,
@@ -40,6 +41,7 @@ export function setupHttpEndpoint({
   context,
   engine,
   jsonParser,
+  authMiddleware = meteorAuthMiddleware,
 } = {}) {
   if (!schema) {
     throw new Error(DDP_APOLLO_SCHEMA_REQUIRED);
@@ -63,5 +65,10 @@ export function setupHttpEndpoint({
   }
 
   WebApp.connectHandlers.use(path, jsonParser);
+
+  if (authMiddleware) {
+    WebApp.connectHandlers.use(path, authMiddleware);
+  }
+
   WebApp.connectHandlers.use(path, (req, res, next) => requestHandler(req, res).catch(next));
 }

--- a/specs/client/apollo-link-meteor.spec.js
+++ b/specs/client/apollo-link-meteor.spec.js
@@ -4,6 +4,8 @@ import chai from 'chai';
 import gql from 'graphql-tag';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { ApolloClient } from 'apollo-client';
+import { loginWithUserId } from './helpers/login';
+import { callPromise } from './helpers/callPromise';
 import { MeteorLink } from '../../lib/client/apollo-link-meteor';
 
 describe('MeteorLink', function () {
@@ -12,6 +14,8 @@ describe('MeteorLink', function () {
       link: new MeteorLink(),
       cache: new InMemoryCache(),
     });
+
+    this.client.cache.reset();
   });
 
   describe('#query', function () {
@@ -24,6 +28,30 @@ describe('MeteorLink', function () {
 
       chai.expect(data).to.deep.equal({ foo: 'bar' });
       chai.expect(loading).to.equal(false);
+    });
+
+    describe('when authenticated', function () {
+      before(async function () {
+        const userId = await callPromise('createTestUser');
+        chai.expect(userId).to.be.a('string');
+        this.userId = userId;
+        await loginWithUserId(userId);
+      });
+
+      after(function (done) {
+        Meteor.logout((err) => { err ? done(err) : done(); });
+      });
+
+      it('returns the userId', async function () {
+        const operation = {
+          query: gql`query { userId }`,
+        };
+
+        const { data } = await this.client.query(operation);
+
+        chai.expect(data.userId).to.be.a('string');
+        chai.expect(data.userId).to.equal(this.userId);
+      });
     });
   });
 });

--- a/specs/client/helpers/callPromise.js
+++ b/specs/client/helpers/callPromise.js
@@ -1,0 +1,7 @@
+export function callPromise(name, ...args) {
+  return new Promise((resolve, reject) => {
+    Meteor.apply(name, args, (err, data) => {
+      err ? reject(err) : resolve(data);
+    });
+  });
+}

--- a/specs/client/helpers/login.js
+++ b/specs/client/helpers/login.js
@@ -1,0 +1,10 @@
+import { Accounts } from 'meteor/accounts-base';
+
+export function loginWithUserId(userId) {
+  return new Promise((resolve, reject) => {
+    Accounts.callLoginMethod({
+      methodArguments: [{ userId }],
+      userCallback: err => (err ? reject(err) : resolve()),
+    });
+  });
+}

--- a/specs/data/resolvers.js
+++ b/specs/data/resolvers.js
@@ -5,6 +5,7 @@ export const FOO_CHANGED_TOPIC = 'foo_changed';
 export const resolvers = {
   Query: {
     foo: () => 'bar',
+    userId: (_, __, { userId } = {}) => userId,
     ddpContextValue: (_, __, { ddpContext } = {}) => ddpContext,
   },
   Subscription: {

--- a/specs/data/typeDefs.js
+++ b/specs/data/typeDefs.js
@@ -1,6 +1,7 @@
 export const typeDefs = [`
 type Query {
   foo: String
+  userId: String
   ddpContextValue: String
 }
 

--- a/specs/server.spec.js
+++ b/specs/server.spec.js
@@ -1,4 +1,8 @@
+// helpers
+import './server/helpers';
+import './server/helpers/setupLoginByUserId';
+
+// specs
 import './server/server.spec';
 import './server/setup.spec';
-import './server/helpers';
 import './server/getUserByLoginToken.spec';

--- a/specs/server.spec.js
+++ b/specs/server.spec.js
@@ -5,4 +5,4 @@ import './server/helpers/setupLoginByUserId';
 // specs
 import './server/server.spec';
 import './server/setup.spec';
-import './server/getUserByLoginToken.spec';
+import './server/getUserIdByLoginToken.spec';

--- a/specs/server/getUserIdByLoginToken.spec.js
+++ b/specs/server/getUserIdByLoginToken.spec.js
@@ -1,12 +1,12 @@
 /* eslint-disable prefer-arrow-callback, func-names */
 /* eslint-env mocha */
 import chai from 'chai';
-import { getUserByLoginToken, NO_VALID_USER_ERROR } from '../../lib/server/getUserByLoginToken';
+import { getUserIdByLoginToken, NO_VALID_USER_ERROR } from '../../lib/server/getUserIdByLoginToken';
 
-describe('getUserByLoginToken', function () {
+describe('getUserIdByLoginToken', function () {
   it('throws error for bad tokens', async function () {
     try {
-      await getUserByLoginToken('foo');
+      await getUserIdByLoginToken('foo');
       chai.expect(false, 'this should not be touched').to.equal(true);
     } catch (err) {
       chai.expect(err).to.equal(NO_VALID_USER_ERROR);

--- a/specs/server/helpers/setupLoginByUserId.js
+++ b/specs/server/helpers/setupLoginByUserId.js
@@ -1,0 +1,19 @@
+import { Accounts } from 'meteor/accounts-base';
+
+Meteor.methods({
+  createTestUser() {
+    return Meteor.users.insert({});
+  },
+});
+
+Accounts.registerLoginHandler('testLogin', (request) => {
+  if (!(typeof request.userId === 'string')) {
+    return undefined;
+  }
+  const user = Meteor.users.findOne(request.userId);
+
+  if (!user) {
+    return { error: new Meteor.Error('USER_NOT_FOUND') };
+  }
+  return { userId: user._id };
+});


### PR DESCRIPTION
This is a more standard approach than detecting userId somewhere inside the GraphQL middleware. This also uses the standard `Authorization` header instead of a custom Meteor token header.

Inspired by https://github.com/apollographql/meteor-integration/issues/120