### PR TITLE
fix(optimization): limit fields retrieval for user

### DIFF
--- a/lib/server/getUserByLoginToken.js
+++ b/lib/server/getUserByLoginToken.js
@@ -15,8 +15,10 @@ export async function getUserByLoginToken(loginToken) {
   // the hashed token is the key to find the possible current user in the db
   const hashedToken = Accounts._hashLoginToken(loginToken);
 
-  // get the possible user from the database
-  const user = await Meteor.users.rawCollection().findOne({ [USER_TOKEN_PATH]: hashedToken });
+  // get the possible user from the database with minimal fields
+  const fields = { _id: 1, 'services.resume': 1 };
+  const user = await Meteor.users.rawCollection()
+    .findOne({ [USER_TOKEN_PATH]: hashedToken }, { fields });
 
   if (!user) { throw NO_VALID_USER_ERROR; }
 


### PR DESCRIPTION
This was suggested at https://github.com/apollographql/meteor-integration/issues/118

This package, purposely, only adds a `userId`, so the developer can decide themselves what else they want to fetch from the user. This means we only need to retrieve the ID and the resume tokens for validation.

If the developer wants to add user data to the context, they can simply add it via a custom context:

```js
function context (currentContext) {
  const newContext = { ...currentContext };

  if (currentContext.userId) {
    newContext.user = Meteor.users.findOne(currentContext.userId, { fields: { /* whatever */ } });
  }

  return newContext;
}
```

One might argue that this would cause 2 requests instead of one, but in my opinion it's way more flexible and will only actually retrieve the data that is required. 2 small requests might still be faster then one large? Besides, you might only need user data in certain resolvers, so it might be even better to only query in those resolvers (using DataLoader for deduping). `userId` says something about authentication. User data should be retrieved like you would with any other data.

In this particular package it's also the case that DDP only offers a userId. By only offering a userId in the HTTP flow we can handle both the same way.

This all also prevents issues like mentioned here: https://github.com/apollographql/meteor-integration/issues/119