### PR TITLE
feat(http): meteor user ID in http handler

### DIFF
--- a/lib/server/createGraphQLMiddleware.js
+++ b/lib/server/createGraphQLMiddleware.js
@@ -1,5 +1,6 @@
 import { execute, parse } from 'graphql';
 import { contextToFunction } from './contextToFunction';
+import { invokeDDP } from './invokeDDP';
 
 export function createGraphQLMiddleware({
   schema,
@@ -14,14 +15,14 @@ export function createGraphQLMiddleware({
       operationName,
     } = req.body;
 
-    const data = await execute(
+    const data = await invokeDDP(async () => execute(
       schema,
       parse(query),
       {},
       await createContext({ userId: req.userId }),
       variables,
       operationName,
-    );
+    ), { userId: req.userId });
 
     const json = JSON.stringify(data);
 

--- a/lib/server/invokeDDP.js
+++ b/lib/server/invokeDDP.js
@@ -1,0 +1,23 @@
+import { DDP } from 'meteor/ddp';
+import { Random } from 'meteor/random';
+
+const { DDPCommon } = Package['ddp-common'];
+
+// For details, please see https://github.com/meteor/meteor/issues/6388
+
+function createInvocation(options) {
+  return new DDPCommon.MethodInvocation({
+    isSimulation: false,
+    setUserId: () => {},
+    unblock: () => {},
+    connection: null,
+    randomSeed: Random.id(),
+    ...options,
+  });
+}
+
+export function invokeDDP(func, options) {
+  const invocation = createInvocation(options);
+
+  return DDP._CurrentMethodInvocation.withValue(invocation, func);
+}

--- a/package.js
+++ b/package.js
@@ -3,6 +3,7 @@ var packages = [
   'ecmascript',
   'promise',
   'webapp',
+  'random',
 ];
 
 Package.describe({

--- a/specs/client/apollo-link-ddp.spec.js
+++ b/specs/client/apollo-link-ddp.spec.js
@@ -82,6 +82,27 @@ describe('DDPMethodLink', function () {
         error: done,
       });
     });
+
+    it('returns the meteorUserId', function (done) {
+      const operation = {
+        query: gql`query { meteorUserId }`,
+      };
+
+      const observer = this.link.request(operation);
+
+      observer.subscribe({
+        next: ({ data }) => {
+          try {
+            chai.expect(data.meteorUserId).to.be.a('string');
+            chai.expect(data.meteorUserId).to.equal(this.userId);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        },
+        error: done,
+      });
+    });
   });
 
   describe('when disconnected', function () {

--- a/specs/client/apollo-link-meteor.spec.js
+++ b/specs/client/apollo-link-meteor.spec.js
@@ -52,6 +52,17 @@ describe('MeteorLink', function () {
         chai.expect(data.userId).to.be.a('string');
         chai.expect(data.userId).to.equal(this.userId);
       });
+
+      it('returns the meteorUserId', async function () {
+        const operation = {
+          query: gql`query { meteorUserId }`,
+        };
+
+        const { data } = await this.client.query(operation);
+
+        chai.expect(data.meteorUserId).to.be.a('string');
+        chai.expect(data.meteorUserId).to.equal(this.userId);
+      });
     });
   });
 });

--- a/specs/data/resolvers.js
+++ b/specs/data/resolvers.js
@@ -6,6 +6,10 @@ export const resolvers = {
   Query: {
     foo: () => 'bar',
     userId: (_, __, { userId } = {}) => userId,
+    // Using Meteor.userId() yourself is not recommended. Use the context userId.
+    // But to support a lot of Meteor packages it's useful, because they use it underwater.
+    // See https://github.com/apollographql/meteor-integration/issues/92
+    meteorUserId: () => Meteor.userId(),
     ddpContextValue: (_, __, { ddpContext } = {}) => ddpContext,
   },
   Subscription: {

--- a/specs/data/typeDefs.js
+++ b/specs/data/typeDefs.js
@@ -2,6 +2,7 @@ export const typeDefs = [`
 type Query {
   foo: String
   userId: String
+  meteorUserId: String
   ddpContextValue: String
 }
 


### PR DESCRIPTION
This will make Meteor.userId work in resolvers when calling them from the HTTP endpoint.

- Why: https://github.com/apollographql/meteor-integration/issues/92
- How: https://github.com/meteor/meteor/issues/6388

We recommend to never use it yourself. Use the userId from the passed context. But this helps to support a lot of Meteor packages out of the box which depend on `Meteor.userId()` to work.