### PR TITLE
feat: custom DDP message listener

### DIFF
--- a/lib/client/apollo-link-ddp.js
+++ b/lib/client/apollo-link-ddp.js
@@ -2,7 +2,10 @@ import { ApolloLink, Observable, split } from 'apollo-link';
 import { Meteor } from 'meteor/meteor';
 import { DEFAULT_METHOD, DEFAULT_PUBLICATION, DEFAULT_CLIENT_CONTEXT_KEY } from '../common/defaults';
 import { isSubscription } from '../common/isSubscription';
-import listenToGraphQLMessages from './listenToGraphQLMessages';
+import {
+  createClientSteamListener,
+  filterGraphQLMessages,
+} from './listenToGraphQLMessages';
 
 function getClientContext(operation, key = DEFAULT_CLIENT_CONTEXT_KEY) {
   return operation.getContext && operation.getContext()[key];
@@ -47,6 +50,7 @@ export class DDPSubscriptionLink extends ApolloLink {
     connection = Meteor.connection,
     publication = DEFAULT_PUBLICATION,
     clientContextKey,
+    ddpListener,
   } = {}) {
     super();
     this.connection = connection;
@@ -55,7 +59,9 @@ export class DDPSubscriptionLink extends ApolloLink {
 
     this.subscriptionObservers = new Map();
 
-    listenToGraphQLMessages(this.connection._stream, ({
+    const listen = ddpListener || createClientSteamListener(this.connection._stream);
+
+    listen(filterGraphQLMessages(({
       subscriptionId,
       result,
     }) => {
@@ -64,7 +70,7 @@ export class DDPSubscriptionLink extends ApolloLink {
       if (observer) {
         observer.next(result);
       }
-    });
+    }));
   }
 
   request(operation = {}) {

--- a/lib/client/apollo-link-ddp.js
+++ b/lib/client/apollo-link-ddp.js
@@ -2,7 +2,7 @@ import { ApolloLink, Observable, split } from 'apollo-link';
 import { DEFAULT_METHOD, DEFAULT_PUBLICATION, DEFAULT_CLIENT_CONTEXT_KEY } from '../common/defaults';
 import { isSubscription } from '../common/isSubscription';
 import {
-  createClientSteamListener,
+  createClientStreamObserver,
   filterGraphQLMessages,
 } from './listenToGraphQLMessages';
 
@@ -59,7 +59,7 @@ export class DDPSubscriptionLink extends ApolloLink {
     connection = getDefaultMeteorConnection(),
     publication = DEFAULT_PUBLICATION,
     clientContextKey,
-    ddpListener,
+    ddpObserver,
   } = {}) {
     super();
     this.connection = connection;
@@ -67,19 +67,21 @@ export class DDPSubscriptionLink extends ApolloLink {
     this.clientContextKey = clientContextKey;
 
     this.subscriptionObservers = new Map();
+    this.ddpObserver = ddpObserver || createClientStreamObserver(this.connection._stream);
 
-    const listen = ddpListener || createClientSteamListener(this.connection._stream);
+    this.ddpSubscription = this.ddpObserver
+      .subscribe({
+        next: filterGraphQLMessages(({
+          subscriptionId,
+          result,
+        }) => {
+          const observer = this.subscriptionObservers.get(subscriptionId);
 
-    listen(filterGraphQLMessages(({
-      subscriptionId,
-      result,
-    }) => {
-      const observer = this.subscriptionObservers.get(subscriptionId);
-
-      if (observer) {
-        observer.next(result);
-      }
-    }));
+          if (observer) {
+            observer.next(result);
+          }
+        }),
+      });
   }
 
   request(operation = {}) {

--- a/lib/client/apollo-link-ddp.js
+++ b/lib/client/apollo-link-ddp.js
@@ -1,5 +1,4 @@
 import { ApolloLink, Observable, split } from 'apollo-link';
-import { Meteor } from 'meteor/meteor';
 import { DEFAULT_METHOD, DEFAULT_PUBLICATION, DEFAULT_CLIENT_CONTEXT_KEY } from '../common/defaults';
 import { isSubscription } from '../common/isSubscription';
 import {
@@ -7,13 +6,23 @@ import {
   filterGraphQLMessages,
 } from './listenToGraphQLMessages';
 
+function getDefaultMeteorConnection() {
+  try {
+    // eslint-disable-next-line global-require
+    const { Meteor } = require('meteor/meteor');
+    return Meteor.connection;
+  } catch (err) {
+    throw new Error('ddp-apollo: missing connection param');
+  }
+}
+
 function getClientContext(operation, key = DEFAULT_CLIENT_CONTEXT_KEY) {
   return operation.getContext && operation.getContext()[key];
 }
 
 export class DDPMethodLink extends ApolloLink {
   constructor({
-    connection = Meteor.connection,
+    connection = getDefaultMeteorConnection(),
     method = DEFAULT_METHOD,
     ddpRetry = true,
     clientContextKey,
@@ -47,7 +56,7 @@ export class DDPMethodLink extends ApolloLink {
 
 export class DDPSubscriptionLink extends ApolloLink {
   constructor({
-    connection = Meteor.connection,
+    connection = getDefaultMeteorConnection(),
     publication = DEFAULT_PUBLICATION,
     clientContextKey,
     ddpListener,

--- a/lib/client/apollo-link-ddp.js
+++ b/lib/client/apollo-link-ddp.js
@@ -53,13 +53,13 @@ export class DDPSubscriptionLink extends ApolloLink {
     this.publication = publication;
     this.clientContextKey = clientContextKey;
 
-    this.subscriptionObservers = {};
+    this.subscriptionObservers = new Map();
 
     listenToGraphQLMessages(this.connection._stream, ({
       subscriptionId,
       result,
     }) => {
-      const observer = this.subscriptionObservers[subscriptionId];
+      const observer = this.subscriptionObservers.get(subscriptionId);
 
       if (observer) {
         observer.next(result);
@@ -73,11 +73,11 @@ export class DDPSubscriptionLink extends ApolloLink {
     const { subscriptionId: subId } = subHandler;
 
     return new Observable((observer) => {
-      this.subscriptionObservers[subId] = observer;
+      this.subscriptionObservers.set(subId, observer);
 
       return () => {
         subHandler.stop();
-        delete this.subscriptionObservers[subId];
+        this.subscriptionObservers.delete(subId);
       };
     });
   }

--- a/lib/client/listenToGraphQLMessages.js
+++ b/lib/client/listenToGraphQLMessages.js
@@ -1,12 +1,7 @@
 import { GRAPHQL_SUBSCRIPTION_MESSAGE_TYPE } from '../common/defaults';
 
-// Listen to a ClientStream for messages and filter out GraphQL subscription messages
-export default function listenToGraphQLMessages(stream, callback) {
-  if (!stream || !callback) {
-    return;
-  }
-
-  stream.on('message', (message) => {
+export function filterGraphQLMessages(callback) {
+  return (message) => {
     const {
       type,
       subId: subscriptionId,
@@ -23,5 +18,16 @@ export default function listenToGraphQLMessages(stream, callback) {
         result,
       });
     }
-  });
+  };
+}
+
+export default function listenToClientStreamMessages(stream, callback) {
+  if (!stream || !callback) {
+    return;
+  }
+  stream.on('message', callback);
+}
+
+export function createClientSteamListener(stream) {
+  return callback => listenToClientStreamMessages(stream, callback);
 }

--- a/lib/client/listenToGraphQLMessages.js
+++ b/lib/client/listenToGraphQLMessages.js
@@ -34,5 +34,13 @@ export function createClientStreamObserver(stream) {
     if (stream) {
       stream.on(event, callback);
     }
+    return () => {
+      if (stream && stream.eventCallbacks && stream.eventCallbacks[event]) {
+        const index = stream.eventCallbacks[event].indexOf(callback);
+        if (index > -1) {
+          stream.eventCallbacks[event].splice(index, 1);
+        }
+      }
+    };
   });
 }

--- a/lib/client/listenToGraphQLMessages.js
+++ b/lib/client/listenToGraphQLMessages.js
@@ -2,11 +2,15 @@ import { GRAPHQL_SUBSCRIPTION_MESSAGE_TYPE } from '../common/defaults';
 
 export function filterGraphQLMessages(callback) {
   return (message) => {
+    const data = typeof message === 'string' ?
+      JSON.parse(message) :
+      message;
+
     const {
       type,
       subId: subscriptionId,
       graphqlData: result,
-    } = JSON.parse(message);
+    } = data;
 
     if (
       type === GRAPHQL_SUBSCRIPTION_MESSAGE_TYPE

--- a/lib/client/listenToGraphQLMessages.js
+++ b/lib/client/listenToGraphQLMessages.js
@@ -1,3 +1,4 @@
+import { Observable } from 'apollo-link';
 import { GRAPHQL_SUBSCRIPTION_MESSAGE_TYPE } from '../common/defaults';
 
 export function filterGraphQLMessages(callback) {
@@ -25,13 +26,13 @@ export function filterGraphQLMessages(callback) {
   };
 }
 
-export default function listenToClientStreamMessages(stream, callback) {
-  if (!stream || !callback) {
-    return;
-  }
-  stream.on('message', callback);
-}
+export function createClientStreamObserver(stream) {
+  return new Observable((observer) => {
+    const event = 'message';
+    const callback = message => observer.next(message);
 
-export function createClientSteamListener(stream) {
-  return callback => listenToClientStreamMessages(stream, callback);
+    if (stream) {
+      stream.on(event, callback);
+    }
+  });
 }

--- a/specs/client/apollo-client.spec.js
+++ b/specs/client/apollo-client.spec.js
@@ -13,10 +13,16 @@ describe('ApolloClient with DDP link', function () {
     // The ApolloClient won't recognize Promise in package tests unless exported like this
     global.Promise = Promise;
 
+    this.link = getDDPLink();
+
     this.client = new ApolloClient({
-      link: getDDPLink(),
+      link: this.link,
       cache: new InMemoryCache(),
     });
+  });
+
+  afterEach(function () {
+    this.link.subscriptionLink.ddpSubscription.unsubscribe();
   });
 
   describe('#query', function () {

--- a/specs/client/apollo-link-ddp.spec.js
+++ b/specs/client/apollo-link-ddp.spec.js
@@ -165,8 +165,17 @@ describe('DDPSubscriptionLink', function () {
     Meteor.call('ddp-apollo/setup', done);
   });
 
+  afterEach(function () {
+    this.link.ddpSubscription.unsubscribe();
+  });
+
   it('should add a default publication', function () {
     chai.expect(this.link.publication).to.equal(DEFAULT_PUBLICATION);
+  });
+
+  it('subscribes to DDP messages', function () {
+    chai.expect(this.link.ddpObserver).to.be.an('object');
+    chai.expect(this.link.ddpSubscription).to.be.an('object');
   });
 
   describe('#request', function () {
@@ -254,6 +263,7 @@ describe('DDPSubscriptionLink', function () {
           try {
             chai.expect(data).to.deep.equal(message);
             subscription.unsubscribe();
+            customObserverLink.ddpSubscription.unsubscribe();
             done();
           } catch (e) {
             done(e);
@@ -267,6 +277,10 @@ describe('DDPSubscriptionLink', function () {
 describe('#getDDPLink', function () {
   beforeEach(function () {
     this.link = getDDPLink();
+  });
+
+  afterEach(function () {
+    this.link.subscriptionLink.ddpSubscription.unsubscribe();
   });
 
   it('should return an instance of ApolloLink', function () {

--- a/specs/client/apollo-link-ddp.spec.js
+++ b/specs/client/apollo-link-ddp.spec.js
@@ -240,19 +240,20 @@ describe('DDPSubscriptionLink', function () {
         query: gql`subscription { fooSub }`,
       };
       const message = { fooSub: 'custom' };
+      let customObserverLink;
 
       const ddpObserver = new Observable((observer) => {
         setTimeout(() => {
           observer.next({
             type: GRAPHQL_SUBSCRIPTION_MESSAGE_TYPE,
-            subId: this.link.subscriptionObservers.keys().next().value,
+            subId: customObserverLink.subscriptionObservers.keys().next().value,
             graphqlData: { data: { ...message } },
           });
           observer.complete();
         }, 10);
       });
 
-      const customObserverLink = new DDPSubscriptionLink({ ddpObserver });
+      customObserverLink = new DDPSubscriptionLink({ ddpObserver });
 
       chai.expect(customObserverLink.ddpObserver).to.equal(ddpObserver);
 
@@ -269,6 +270,7 @@ describe('DDPSubscriptionLink', function () {
             done(e);
           }
         },
+        error: done,
       });
     });
   });

--- a/specs/client/apollo-link-meteor.spec.js
+++ b/specs/client/apollo-link-meteor.spec.js
@@ -10,12 +10,18 @@ import { MeteorLink } from '../../lib/client/apollo-link-meteor';
 
 describe('MeteorLink', function () {
   beforeEach(function () {
+    this.link = new MeteorLink();
+
     this.client = new ApolloClient({
-      link: new MeteorLink(),
+      link: this.link,
       cache: new InMemoryCache(),
     });
 
     this.client.cache.reset();
+  });
+
+  afterEach(function () {
+    this.link.subscriptionLink.ddpSubscription.unsubscribe();
   });
 
   describe('#query', function () {


### PR DESCRIPTION
This will help support non-Meteor front-ends. A custom connection and DDP listener can be provided, to support libraries as `ddp.js`.

Next step would be to make the client code stand-alone in an npm package.