### PR TITLE
Remove graphql dependency

### DIFF
--- a/packages/apollo-link-ddp/README.md
+++ b/packages/apollo-link-ddp/README.md
@@ -3,8 +3,10 @@ This is the client part of the DDP setup for Apollo. It works out of the box in 
 
 ## Installation
 ```
-meteor npm install --save apollo-link-ddp apollo-link graphql
+meteor npm install --save apollo-link-ddp apollo-link graphql apollo-utilities
 ```
+
+Please note that [`apollo-utilities`](https://www.npmjs.com/package/apollo-utilities) is a peer dependency of this package.
 
 ## Setup
 This packages gives you a `DDPLink` for your Apollo Client. Creating an Apollo Client is the same as with any other Apollo Link.

--- a/packages/apollo-link-ddp/common/isSubscription.js
+++ b/packages/apollo-link-ddp/common/isSubscription.js
@@ -1,4 +1,4 @@
-import { getMainDefinition } from 'apollo-utilities';
+const { getMainDefinition } = require('apollo-utilities');
 
 const isSubscription = ({ query }) => {
   const { kind, operation } = getMainDefinition(query);

--- a/packages/apollo-link-ddp/common/isSubscription.js
+++ b/packages/apollo-link-ddp/common/isSubscription.js
@@ -1,10 +1,8 @@
-const { getOperationAST } = require('graphql');
+import { getMainDefinition } from 'apollo-utilities';
 
-const isSubscription = (operation) => {
-  const { query, operationName } = operation;
-  const operationAST = getOperationAST(query, operationName);
-
-  return !!operationAST && operationAST.operation === 'subscription';
+const isSubscription = ({ query }) => {
+  const { kind, operation } = getMainDefinition(query);
+  return kind === 'OperationDefinition' && operation === 'subscription';
 };
 
 module.exports = isSubscription;

--- a/packages/apollo-link-ddp/package.json
+++ b/packages/apollo-link-ddp/package.json
@@ -4,7 +4,8 @@
   "description": "Apollo Link using DDP",
   "main": "index.js",
   "peerDependencies": {
-    "apollo-link": "^1.0.0"
+    "apollo-link": "^1.0.0",
+    "apollo-utilities": "^1.1.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Changes how the `isSubscription` utility works so that the package doesn't load the entire `graphql` module, which is a very heavy ~250 kb.

The proposed implementation matches what is described in the [Apollo documentation](https://www.apollographql.com/docs/react/advanced/subscriptions.html#subscriptions-client).