### PR TITLE
Expose createGraphQLPublication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## vNEXT
+ - Expose `createGraphQLPublication` on the server. (https://github.com/Swydo/ddp-apollo/pull/276)
+
 ## 2.0.0
 
 - Move client code to stand-alone npm package [#207](https://github.com/Swydo/ddp-apollo/pull/207)

--- a/lib/server/createGraphQLPublication.js
+++ b/lib/server/createGraphQLPublication.js
@@ -9,6 +9,7 @@ import { contextToFunction } from './contextToFunction';
 
 // The 'pong' message is the only messages that is ignored by the client-side DDP parser
 const SUBSCRIPTION_MESSAGE_TYPE = 'pong';
+const { warn } = console;
 
 export function createGraphQLPublication({
   schema,
@@ -16,7 +17,7 @@ export function createGraphQLPublication({
   publication = DEFAULT_PUBLICATION,
 } = {}) {
   if (!subscribe) {
-    console.warn('DDP-Apollo: You need graphl@0.11 or higher for subscription support');
+    warn('DDP-Apollo: You need graphl@0.11 or higher for subscription support');
     return;
   }
 

--- a/lib/server/setup.js
+++ b/lib/server/setup.js
@@ -35,6 +35,8 @@ export function setup({
   });
 }
 
+export { createGraphQLPublication };
+
 export function setupHttpEndpoint({
   schema,
   path = DEFAULT_PATH,

--- a/specs/server.js
+++ b/specs/server.js
@@ -3,6 +3,7 @@ import './server/helpers';
 import './server/helpers/setupLoginByUserId';
 
 // specs
+import './server/exports';
 import './server/server';
 import './server/setup';
 import './server/getUserIdByLoginToken';

--- a/specs/server/exports.js
+++ b/specs/server/exports.js
@@ -1,0 +1,27 @@
+/* eslint-disable prefer-arrow-callback, func-names, import/named */
+/* eslint-env mocha */
+import { expect } from 'chai';
+import {
+  DDP_APOLLO_SCHEMA_REQUIRED,
+  setup,
+  createGraphQLPublication,
+  setupHttpEndpoint,
+} from '../../server';
+
+describe('Server exports', function () {
+  it('exports the DDP_APOLLO_SCHEMA_REQUIRED constant', function () {
+    expect(DDP_APOLLO_SCHEMA_REQUIRED).to.be.a('string');
+  });
+
+  it('exports the setup function', function () {
+    expect(setup).to.be.a('function');
+  });
+
+  it('exports the createGraphQLPublication function', function () {
+    expect(createGraphQLPublication).to.be.a('function');
+  });
+
+  it('exports the setupHttpEndpoint function', function () {
+    expect(setupHttpEndpoint).to.be.a('function');
+  });
+});


### PR DESCRIPTION
Simply exposes `createGraphQLPublication` to allow us to use ddp-apollo strictly for subscriptions, [as per the docs.](https://github.com/Swydo/ddp-apollo#server-setup-1) 

Fixes https://github.com/Swydo/ddp-apollo/issues/208