### PR TITLE
Make client module lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0
+- The client module has been marked as lazy, so if using the Meteor package, `DDPLink` will only be included in the bundle when `import`ed. (https://github.com/Swydo/ddp-apollo/pull/277)
+
 ## 2.0.0
 
 - Move client code to stand-alone npm package [#207](https://github.com/Swydo/ddp-apollo/pull/207)

--- a/package.js
+++ b/package.js
@@ -17,7 +17,7 @@ Package.describe({
 Package.onUse(function use(api) {
   api.versionsFrom('1.3.2.4');
   api.use(packages);
-  api.mainModule('client.js', 'client');
+  api.mainModule('client.js', 'client', { lazy: true });
   api.mainModule('server.js', 'server');
 });
 


### PR DESCRIPTION
Simply makes the meteor package's client module lazy. This just prevents the module from being included in the app bundle until it is `import`ed. This is particularly useful if the developer opts to use this atmosphere package with the `apollo-link-ddp` npm module instead; without the `lazy` option, the client will get bundled with app no matter what.

Note that this includes a bump to `2.2.0`. This is because my other PR (https://github.com/Swydo/ddp-apollo/pull/276) bumps to `2.1.0`.