### PR TITLE
Verify that return is a function before executing in onStop.

### DIFF
--- a/lib/server/createGraphQLPublication.js
+++ b/lib/server/createGraphQLPublication.js
@@ -53,7 +53,7 @@ export function createGraphQLPublication({
         this.ready();
 
         // When the Meteor subscriptions stops we should break out of the iterator
-        this.onStop(() => iterator.return());
+        this.onStop(() => iterator.return && iterator.return());
 
         return forAwaitEach(iterator, (graphqlData) => {
           session.socket.send(JSON.stringify({

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "graphql-tag": "2.10.1",
     "graphql-tools": "4.0.6",
     "simpleddp": "^2.1.0",
-    "sinon": "7.4.0"
+    "sinon": "7.4.1"
   },
   "scripts": {
     "doctoc": "doctoc ./README.md",


### PR DESCRIPTION
Let's say you have a subscription set up that will throw an error if the user is unauthorized to make that subscription:

```javascript
subscribe: (_, __, { userId }) => {
    if (!userId) throw AuthenticationError('Must be signed in.');
    
    // ... 
}
```

The server will throw an error from an uncaught exception: 

```
Exception in onStop callback: TypeError: iterator.return is not a function
     at Subscription.onStop (packages/swydo:ddp-apollo/lib/server/createGraphQLPublication.js:56:27)
     at runWithEnvironment (packages/meteor.js:1286:24)
     at packages/meteor.js:1299:14
     at packages/ddp-server/livedata_server.js:1158:7
     at Array.forEach (<anonymous>)
     at Function._.each._.forEach (packages/underscore.js:139:11)
     at Subscription._callStopCallbacks (packages/ddp-server/livedata_server.js:1157:7)
     at Subscription._deactivate (packages/ddp-server/livedata_server.js:1147:10)
     at Session._stopSubscription (packages/ddp-server/livedata_server.js:873:18)
     at Subscription.stop (packages/ddp-server/livedata_server.js:1215:19)
     at Promise.resolve.then.then.then.then (packages/swydo:ddp-apollo/lib/server/createGraphQLPublication.js:68:24)
```

From what I an understand, this is happening because the subscription doesn't actually return an iterator when the error is thrown, but that publication ddp-apollo sets up assumes that there will be one. I'm thinking that the error caught [here](https://github.com/Swydo/ddp-apollo/blob/master/lib/server/createGraphQLPublication.js#L69) causes the [`onStop` to run](https://github.com/Swydo/ddp-apollo/blob/master/lib/server/createGraphQLPublication.js#L56), which then errors out because a proper iterator was never returned. This PR just checks that the `return` function exists before trying to call it, which will prevent the above error from happening.

Personally, I started encountering this problem whenever a user logs out. When the user logs out, the ddp-apollo publication reruns because `userId` has changed, which will then call the GraphQL subscription resolver which then throws an error because `userId` is not defined.