### PR TITLE
avoid attribute errors when accessing `connection`

### DIFF
--- a/src/invokeDDP.js
+++ b/src/invokeDDP.js
@@ -10,7 +10,7 @@ function createInvocation(options) {
     isSimulation: false,
     setUserId: () => {},
     unblock: () => {},
-    connection: null,
+    connection: {},
     randomSeed: Random.id(),
     ...options,
   });


### PR DESCRIPTION
Thank you for publishing `ddp-apollo`!  Even though I am not using it directly, I managed to solve a humongous old bug in my application while studying how you managed to invoke dpp calls (#190).

Things were going pretty well until I started getting errors while trying to call Meteor's `verifyEmail`. 
The problem was that `connection: null` results in `(null).id` at _accounts_server.js:855_:

https://github.com/meteor/meteor/blob/573c9dc478b15df70fa26c4a753d62077df1b066/packages/accounts-base/accounts_server.js#L854-L856

Setting `connection: {}` solves the issue to me, so I would like to know if there is any reason to keep `null` instead.
